### PR TITLE
Widget Expression

### DIFF
--- a/src/Misc/ViewExpressionTrait.php
+++ b/src/Misc/ViewExpressionTrait.php
@@ -19,6 +19,7 @@ trait ViewExpressionTrait
             if (property_exists($this, 'widget')) {
                 return new WidgetExpression($html, $this->widget);
             }
+            
             return new HtmlString($html);
         }
 

--- a/src/Misc/ViewExpressionTrait.php
+++ b/src/Misc/ViewExpressionTrait.php
@@ -16,6 +16,9 @@ trait ViewExpressionTrait
     protected function convertToViewExpression($html)
     {
         if (interface_exists('Illuminate\Contracts\Support\Htmlable') && class_exists('Illuminate\Support\HtmlString')) {
+            if (property_exists($this, 'widget')) {
+                return new WidgetExpression($html, $this->widget);
+            }
             return new HtmlString($html);
         }
 

--- a/src/Misc/ViewExpressionTrait.php
+++ b/src/Misc/ViewExpressionTrait.php
@@ -19,7 +19,7 @@ trait ViewExpressionTrait
             if (property_exists($this, 'widget')) {
                 return new WidgetExpression($html, $this->widget);
             }
-            
+
             return new HtmlString($html);
         }
 

--- a/src/Misc/WidgetExpression.php
+++ b/src/Misc/WidgetExpression.php
@@ -2,18 +2,18 @@
 
 namespace Arrilot\Widgets\Misc;
 
-use Illuminate\View\Expression;
 use Arrilot\Widgets\AbstractWidget;
+use Illuminate\View\Expression;
 
 /**
- * Represents an widget to the view
+ * Represents an widget to the view.
  */
 class WidgetExpression extends Expression
 {
     protected $widget;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      * @param AbstractWidget $widget instance of the widget this expression
      *                               represents
      */
@@ -25,7 +25,7 @@ class WidgetExpression extends Expression
     }
 
     /**
-     * Get the instance of the widget this expression represents
+     * Get the instance of the widget this expression represents.
      *
      * @return AbstractWidget
      */
@@ -35,10 +35,10 @@ class WidgetExpression extends Expression
     }
 
     /**
-     * Call a method directly on the widget instance
+     * Call a method directly on the widget instance.
      *
-     * @param  string $method method name
-     * @param  array $params
+     * @param string $method method name
+     * @param array  $params
      * @return mixed
      */
     public function __call($method, array $params = [])

--- a/src/Misc/WidgetExpression.php
+++ b/src/Misc/WidgetExpression.php
@@ -22,7 +22,6 @@ class WidgetExpression extends Expression
     {
         $this->widget = $widget;
         parent::__construct($html);
-
     }
 
     /**

--- a/src/Misc/WidgetExpression.php
+++ b/src/Misc/WidgetExpression.php
@@ -14,6 +14,7 @@ class WidgetExpression extends Expression
 
     /**
      * {@inheritdoc}
+     *
      * @param AbstractWidget $widget instance of the widget this expression
      *                               represents
      */
@@ -39,6 +40,7 @@ class WidgetExpression extends Expression
      *
      * @param string $method method name
      * @param array  $params
+     * 
      * @return mixed
      */
     public function __call($method, array $params = [])

--- a/src/Misc/WidgetExpression.php
+++ b/src/Misc/WidgetExpression.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Arrilot\Widgets\Misc;
+
+use Illuminate\View\Expression;
+use Arrilot\Widgets\AbstractWidget;
+
+/**
+ * Represents an widget to the view
+ */
+class WidgetExpression extends Expression
+{
+    protected $widget;
+
+    /**
+     * @inheritdoc
+     * @param AbstractWidget $widget instance of the widget this expression
+     *                               represents
+     */
+    public function __construct($html, AbstractWidget $widget)
+    {
+        $this->widget = $widget;
+        parent::__construct($html);
+
+    }
+
+    /**
+     * Get the instance of the widget this expression represents
+     *
+     * @return AbstractWidget
+     */
+    public function getWidget()
+    {
+        return $this->widget;
+    }
+
+    /**
+     * Call a method directly on the widget instance
+     *
+     * @param  string $method method name
+     * @param  array $params
+     * @return mixed
+     */
+    public function __call($method, array $params = [])
+    {
+        if (is_callable($this->widget, $method)) {
+            return call_user_func_array([$this->widget, $method], $params);
+        }
+        throw new InvalidArgumentException(
+            sprintf(
+                '"%s" does not have a method of "%s"',
+                get_class($this->widget),
+                $method
+            )
+        );
+    }
+}

--- a/src/Misc/WidgetExpression.php
+++ b/src/Misc/WidgetExpression.php
@@ -40,7 +40,7 @@ class WidgetExpression extends Expression
      *
      * @param string $method method name
      * @param array  $params
-     * 
+     *
      * @return mixed
      */
     public function __call($method, array $params = [])

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -6,6 +6,7 @@ use Arrilot\Widgets\Factories\WidgetFactory;
 use Arrilot\Widgets\Test\Dummies\TestCachedWidget;
 use Arrilot\Widgets\Test\Support\TestApplicationWrapper;
 use Arrilot\Widgets\Test\Support\TestCase;
+use Arrilot\Widgets\AbstractWidget;
 
 class WidgetFactoryTest extends TestCase
 {
@@ -150,5 +151,12 @@ class WidgetFactoryTest extends TestCase
         $widget = new TestCachedWidget();
 
         $this->assertEquals('Cached output. Key: '.$key.', minutes: '.$widget->cacheTime, $output);
+    }
+
+    public function testWidgetExpression()
+    {
+        $widget = $this->factory->run('Slider');
+
+        $this->assertInstanceOf('\\Arrilot\\Widgets\\AbstractWidget', $widget->getWidget());
     }
 }

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -6,7 +6,6 @@ use Arrilot\Widgets\Factories\WidgetFactory;
 use Arrilot\Widgets\Test\Dummies\TestCachedWidget;
 use Arrilot\Widgets\Test\Support\TestApplicationWrapper;
 use Arrilot\Widgets\Test\Support\TestCase;
-use Arrilot\Widgets\AbstractWidget;
 
 class WidgetFactoryTest extends TestCase
 {


### PR DESCRIPTION
I've updated the `ViewExpressionTrait` to add support for a `WidgetExpression`.

This `WidgetExpression` extends from the base Expression (aka `HtmlString`) to not only expose the widgets run() output, but also allow the widget to be reused and/or use other public methods within the widget. e.g.

``` php
// run & output the core logic of recent news
{{ $recentNews = Widget::run('recentNews') }}
// additional functionality
{{ $recentNews->anotherPublicMethod() }}
// alternatively
{{ $recentNews->getWidget()->anotherPublicMethod() }}
```
