### PR TITLE
Fix #46 - config() error.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -61,7 +61,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $routeConfig = [
             'namespace'  => 'Arrilot\Widgets\Controllers',
             'prefix'     => 'arrilot',
-            'middleware' => $this->app->config('laravel-widgets.route_middleware', []),
+            'middleware' => $this->app['config']->get('laravel-widgets.route_middleware', []),
         ];
 
         if (!$this->app->routesAreCached()) {


### PR DESCRIPTION
[Symfony\Component\Debug\Exception\FatalThrowableError]
Call to undefined method Illuminate\Foundation\Application::config()
