### PR TITLE
Fix bug: when a CRLF is in @widget, blade will complains! It is not s…

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,16 +74,15 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return "<?php echo app('arrilot.widget')->run{$expression}; ?>";
         });
 
-        Blade::directive('async-widget', function ($expression) {
-            return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
-        });
+        // Blade::directive cannot recognize @async-widget, so @async-widget still use the custom matcher.
+        $this->registerBladeDirective('async-widget', '$1<?php echo app("arrilot.async-widget")->run$2; ?>');
 
         Blade::directive('asyncWidget', function ($expression) {
             return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
         });
 
-        Blade::directive('asyncWidget', function ($expression) {
-            return "<?php echo app('arrilot.arrilot.widget-group-collection')->group{$expression}->display(); ?>";
+        Blade::directive('widgetGroup', function ($expression) {
+            return "<?php echo app('arrilot.widget-group-collection')->group{$expression}->display(); ?>";
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -70,19 +70,19 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             });
         }
 
-        Blade::directive('widget', function($expression){
+        Blade::directive('widget', function ($expression) {
             return "<?php echo app('arrilot.widget')->run{$expression}; ?>";
         });
 
-        Blade::directive('async-widget', function($expression){
+        Blade::directive('async-widget', function ($expression) {
             return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
         });
 
-        Blade::directive('asyncWidget', function($expression){
+        Blade::directive('asyncWidget', function ($expression) {
             return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
         });
 
-        Blade::directive('asyncWidget', function($expression){
+        Blade::directive('asyncWidget', function ($expression) {
             return "<?php echo app('arrilot.arrilot.widget-group-collection')->group{$expression}->display(); ?>";
         });
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -70,10 +70,21 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             });
         }
 
-        $this->registerBladeDirective('widget', '$1<?php echo app("arrilot.widget")->run$2; ?>');
-        $this->registerBladeDirective('async-widget', '$1<?php echo app("arrilot.async-widget")->run$2; ?>');
-        $this->registerBladeDirective('asyncWidget', '$1<?php echo app("arrilot.async-widget")->run$2; ?>');
-        $this->registerBladeDirective('widgetGroup', '$1<?php echo  app("arrilot.widget-group-collection")->group$2->display(); ?>');
+        Blade::directive('widget', function($expression){
+            return "<?php echo app('arrilot.widget')->run{$expression}; ?>";
+        });
+
+        Blade::directive('async-widget', function($expression){
+            return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
+        });
+
+        Blade::directive('asyncWidget', function($expression){
+            return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
+        });
+
+        Blade::directive('asyncWidget', function($expression){
+            return "<?php echo app('arrilot.arrilot.widget-group-collection')->group{$expression}->display(); ?>";
+        });
     }
 
     /**


### PR DESCRIPTION
I've got a raw output when there is a CRLF in @widget(...). For example:

``` blade

@widget('pager', [
          "baseUrl" => "/product",
          "count" => $count,
])

```

output is still:

``` php
@widget('pager', [
          "baseUrl" => "/product",
          "count" => $count,
])

```

When I dived into laravel-widgets' sources, I was surprised about the matcher in `\Arrilot\Widgets\ServiceProvider::createMatcher`. Why are you recreate a matcher?

After I had used `Blade::directive` instead of `$this->registerBladeDirective`, it worked. The blade compile result is correct:

``` php
<?php echo app('arrilot.widget')->run('pager', [
          "baseUrl" => "/product",
          "count" => $count,
]); ?>
```

So, hope you can accept this PR. 

Sorry for my poor English.
