### PR TITLE
Fix blade directives on Laravel 5.3

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,15 +71,15 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         }
 
         Blade::directive('widget', function ($expression) {
-            return "<?php echo app('arrilot.widget')->run{$expression}; ?>";
+            return "<?php echo app('arrilot.widget')->run({$expression}); ?>";
         });
 
         Blade::directive('asyncWidget', function ($expression) {
-            return "<?php echo app('arrilot.async-widget')->run{$expression}; ?>";
+            return "<?php echo app('arrilot.async-widget')->run({$expression}); ?>";
         });
 
         Blade::directive('widgetGroup', function ($expression) {
-            return "<?php echo app('arrilot.widget-group-collection')->group{$expression}->display(); ?>";
+            return "<?php echo app('arrilot.widget-group-collection')->group({$expression})->display(); ?>";
         });
     }
 


### PR DESCRIPTION
On Laravel 5.3, parenthesis on expressions are automatically stripped.

https://github.com/laravel/framework/pull/14986
https://laravel.com/docs/5.3/upgrade
