### PR TITLE
Make widget classes with the Illuminate Container

### DIFF
--- a/src/Factories/AbstractWidgetFactory.php
+++ b/src/Factories/AbstractWidgetFactory.php
@@ -133,7 +133,7 @@ abstract class AbstractWidgetFactory
             throw new InvalidWidgetClassException('Class "'.$widgetClass.'" must extend "Arrilot\Widgets\AbstractWidget" class');
         }
 
-        $this->widget = $this->app->make( $widgetClass,  [ 'config' => $this->widgetConfig ]  );
+        $this->widget = $this->app->make($widgetClass, ['config' => $this->widgetConfig]);
 
         if (static::$allowOnlyWidgetsWithDisabledEncryption && $this->widget->encryptParams) {
             throw new EncryptException('Widget "'.$widgetClass.'" was not called properly');

--- a/src/Factories/AbstractWidgetFactory.php
+++ b/src/Factories/AbstractWidgetFactory.php
@@ -133,7 +133,7 @@ abstract class AbstractWidgetFactory
             throw new InvalidWidgetClassException('Class "'.$widgetClass.'" must extend "Arrilot\Widgets\AbstractWidget" class');
         }
 
-        $this->widget = new $widgetClass($this->widgetConfig);
+        $this->widget = $this->app->make( $widgetClass,  [ 'config' => $this->widgetConfig ]  );
 
         if (static::$allowOnlyWidgetsWithDisabledEncryption && $this->widget->encryptParams) {
             throw new EncryptException('Widget "'.$widgetClass.'" was not called properly');

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -101,7 +101,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
         if (is_subclass_of($abstract, AbstractWidget::class)) {
             $app = \Illuminate\Container\Container::getInstance();
 
-            return $app->make($abstract, $parameters);
+            return $app->makeWith($abstract, $parameters);
         }
 
         throw new InvalidArgumentException("Binding {$abstract} cannot be resolved while testing");

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -2,6 +2,7 @@
 
 namespace Arrilot\Widgets\Test\Support;
 
+use Arrilot\Widgets\AbstractWidget;
 use Arrilot\Widgets\Contracts\ApplicationWrapperContract;
 use Arrilot\Widgets\Factories\AsyncWidgetFactory;
 use Arrilot\Widgets\Factories\WidgetFactory;
@@ -95,6 +96,11 @@ class TestApplicationWrapper implements ApplicationWrapperContract
 
         if ($abstract == 'encrypter') {
             return new TestEncrypter();
+        }
+
+        if (is_subclass_of($abstract, AbstractWidget::class)) {
+            $app = \Illuminate\Container\Container::getInstance();
+            return $app->make($abstract, $parameters);
         }
 
         throw new InvalidArgumentException("Binding {$abstract} cannot be resolved while testing");

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -100,6 +100,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
 
         if (is_subclass_of($abstract, AbstractWidget::class)) {
             $app = \Illuminate\Container\Container::getInstance();
+
             return $app->make($abstract, $parameters);
         }
 


### PR DESCRIPTION
Also changed the TestApplicationWrapper to use the Illuminate Container when the abstract class is a subclass of AbstractWidget

This makes it possible to have a widget class like this:
```php
<?php

namespace App\Widgets;

use App\Contracts\UserRepository;
use Arrilot\Widgets\AbstractWidget;

class RecentlyCreatedUsers extends AbstractWidget
{
    /**
     * The configuration array.
     *
     * @var array
     */
    protected $config = [];

    private $users;

    public function __construct(array $config = [], UserRepository $userRepository)
    {
        parent::__construct($config);

        $this->users = $userRepository;
    }

    /**
     * Treat this method as a controller action.
     * Return view() or other content to display.
     */
    public function run()
    {
        $users = $this->users->recentlyCreated();

        return view('widgets.recently_created_users', [
            'config' => $this->config,
        ])->withUsers($users);
    }
}
```