### PR TITLE
Widgets aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,44 @@ No problem, there are several ways to call those widgets:
 @widget('\App\Http\Some\Namespace\Widget', $config)
 ```
 
+4) Use an alias by setting it in the config, example :
+```php
+[
+    'aliases' => [
+        'example' => \App\Http\Some\Namespace\Widget::class,
+        'news' => [
+            'list' => \Vendor\NewsPackage\Widgets\NewsList::class,
+        ]
+    ]    
+]
+```
+
+Then you can call aliases by they key :
+
+```php
+@widget('example', $config)    // = \App\Http\Some\Namespace\Widget
+@widget('news.list', $config)  // = \Vendor\NewsPackage\Widgets\NewsList
+```
+
+NB : aliases does not have priority on dot notation
+
+Aliases can be useful when you want to include widgets in your own packages. To include your package's widgets you just 
+have to merge aliases arrays in the service provider.
+
+```php
+public function register()
+{
+    $config = array_merge_recursive(
+        config('laravel-widgets.aliases'),
+        [ 'mypackagealias' => \MyVendorName\MyPackageName\Widgets\MyWidget::class ]
+    );
+
+    config(['laravel-widgets.aliases' => $config]);
+    
+    // Allows you to call @widget('mypackagealias')
+}
+``` 
+
 ## Asynchronous widgets
 
 In some situations it can be very beneficial to load widget content with AJAX.

--- a/src/Misc/AliasNotFoundException.php
+++ b/src/Misc/AliasNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Arrilot\Widgets\Misc;
+
+use Exception;
+
+class AliasNotFoundException extends Exception
+{
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -24,6 +24,6 @@ return [
      * Define aliases to classes
      */
      'aliases' => [
-          'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
+         // 'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
      ]
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,11 @@ return [
     * Relative path from the base directory to a plain widget stub.
     */
     'widget_plain_stub'  => 'vendor/arrilot/laravel-widgets/src/Console/stubs/widget_plain.stub',
+
+     /*
+     * Define aliases to classes
+     */
+     'aliases' => [
+          'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
+     ]
 ];

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -20,6 +20,9 @@ class TestApplicationWrapper implements ApplicationWrapperContract
     public $config = [
         'laravel-widgets.default_namespace'         => 'Arrilot\Widgets\Test\Dummies',
         'laravel-widgets.use_jquery_for_ajax_calls' => true,
+        'laravel-widgets.aliases.valid'             => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class,
+        'laravel-widgets.aliases.invalid'           => \Arrilot\Widgets\Test\Dummies\Invalid::class,
+        'laravel-widgets.aliases.empty'             => '',
     ];
 
     /**
@@ -54,7 +57,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Get the specified configuration value.
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */
@@ -81,7 +84,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Wrapper around app()->make().
      *
      * @param string $abstract
-     * @param array  $parameters
+     * @param array $parameters
      *
      * @return mixed
      */

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -68,6 +68,27 @@ class WidgetFactoryTest extends TestCase
         $this->assertEquals('Default test slider was executed with $slides = 6', $output);
     }
 
+    public function testItCanRunWidgetsUsingAlias()
+    {
+        $output = $this->factory->run('valid');
+
+        $this->assertEquals('Default test slider was executed with $slides = 6', $output);
+    }
+
+    public function testItThrowsExceptionForBadAlias()
+    {
+        $this->expectException('\Arrilot\Widgets\Misc\InvalidWidgetClassException');
+
+        $output = $this->factory->run('invalid');
+    }
+
+    public function testItThrowsExceptionForEmptyAlias()
+    {
+        $this->expectException('\Arrilot\Widgets\Misc\AliasNotFoundException');
+
+        $output = $this->factory->run('empty');
+    }
+
     public function testItLoadsWidgetsFromRootNamespaceFirst()
     {
         $output = $this->factory->run('Exception');
@@ -110,16 +131,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<div id="arrilot-widget-container-1" style="display:inline" class="arrilot-widget-container">Feed was executed with $slides = 6'.
-                '<script type="text/javascript">'.
-                    'setTimeout( function() {'.
-                        'var widgetTimer1 = setInterval(function() {'.
-                            'if (window.$) {'.
-                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
-                                'clearInterval(widgetTimer1);'.
-                            '}'.
-                        '}, 100);'.
-                    '}, 10000)'.
-                '</script>'.
+            '<script type="text/javascript">'.
+            'setTimeout( function() {'.
+            'var widgetTimer1 = setInterval(function() {'.
+            'if (window.$) {'.
+            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
+            'clearInterval(widgetTimer1);'.
+            '}'.
+            '}, 100);'.
+            '}, 10000)'.
+            '</script>'.
             '</div>', $output);
     }
 
@@ -129,16 +150,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<p id="arrilot-widget-container-1" data-id="123">Dummy Content'.
-                '<script type="text/javascript">'.
-                    'setTimeout( function() {'.
-                        'var widgetTimer1 = setInterval(function() {'.
-                            'if (window.$) {'.
-                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
-                                'clearInterval(widgetTimer1);'.
-                            '}'.
-                        '}, 100);'.
-                    '}, 10000)'.
-                '</script>'.
+            '<script type="text/javascript">'.
+            'setTimeout( function() {'.
+            'var widgetTimer1 = setInterval(function() {'.
+            'if (window.$) {'.
+            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
+            'clearInterval(widgetTimer1);'.
+            '}'.
+            '}, 100);'.
+            '}, 10000)'.
+            '</script>'.
             '</p>', $output);
     }
 

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -131,16 +131,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<div id="arrilot-widget-container-1" style="display:inline" class="arrilot-widget-container">Feed was executed with $slides = 6'.
-            '<script type="text/javascript">'.
-            'setTimeout( function() {'.
-            'var widgetTimer1 = setInterval(function() {'.
-            'if (window.$) {'.
-            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
-            'clearInterval(widgetTimer1);'.
-            '}'.
-            '}, 100);'.
-            '}, 10000)'.
-            '</script>'.
+                '<script type="text/javascript">'.
+                    'setTimeout( function() {'.
+                        'var widgetTimer1 = setInterval(function() {'.
+                            'if (window.$) {'.
+                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
+                                'clearInterval(widgetTimer1);'.
+                            '}'.
+                        '}, 100);'.
+                    '}, 10000)'.
+                '</script>'.
             '</div>', $output);
     }
 
@@ -150,16 +150,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<p id="arrilot-widget-container-1" data-id="123">Dummy Content'.
-            '<script type="text/javascript">'.
-            'setTimeout( function() {'.
-            'var widgetTimer1 = setInterval(function() {'.
-            'if (window.$) {'.
-            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
-            'clearInterval(widgetTimer1);'.
-            '}'.
-            '}, 100);'.
-            '}, 10000)'.
-            '</script>'.
+                '<script type="text/javascript">'.
+                    'setTimeout( function() {'.
+                        'var widgetTimer1 = setInterval(function() {'.
+                            'if (window.$) {'.
+                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
+                                'clearInterval(widgetTimer1);'.
+                            '}'.
+                        '}, 100);'.
+                    '}, 10000)'.
+                '</script>'.
             '</p>', $output);
     }
 


### PR DESCRIPTION
Hello Arrilot, me again...

I have to deliver widgets with a package. After analyzing how to make sure that widgets can be called after the installation of the package, I found this solution.

In other words, we will enter aliases in the configuration file, these aliases can then be called directly with the Blade directive. The advantage is therefore to be able to merge the configuration values to call the widgets of the package (see my modifications in README.md).

I'll let you analyze my modifications, I added the tests.