### PR TITLE
Widgets aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,44 @@ No problem, there are several ways to call those widgets:
 @widget('\App\Http\Some\Namespace\Widget', $config)
 ```
 
+4) Use an alias by setting it in the config, example :
+```php
+[
+    'aliases' => [
+        'example' => \App\Http\Some\Namespace\Widget::class,
+        'news' => [
+            'list' => \Vendor\NewsPackage\Widgets\NewsList::class,
+        ]
+    ]    
+]
+```
+
+Then you can call aliases by they key :
+
+```php
+@widget('example', $config)    // = \App\Http\Some\Namespace\Widget
+@widget('news.list', $config)  // = \Vendor\NewsPackage\Widgets\NewsList
+```
+
+NB : aliases does not have priority on dot notation
+
+Aliases can be useful when you want to include widgets in your own packages. To include your package's widgets you just 
+have to merge aliases arrays in the service provider.
+
+```php
+public function register()
+{
+    $config = array_merge_recursive(
+        config('laravel-widgets.aliases'),
+        [ 'mypackagealias' => \MyVendorName\MyPackageName\Widgets\MyWidget::class ]
+    );
+
+    config(['laravel-widgets.aliases' => $config]);
+    
+    // Allows you to call @widget('mypackagealias')
+}
+``` 
+
 ## Asynchronous widgets
 
 In some situations it can be very beneficial to load widget content with AJAX.

--- a/src/Console/WidgetMakeCommand.php
+++ b/src/Console/WidgetMakeCommand.php
@@ -224,7 +224,7 @@ class WidgetMakeCommand extends GeneratorCommand
         // convert to snake_case part by part to avoid unexpected underscores.
         $nameArray = explode('/', $name);
         array_walk($nameArray, function (&$part) {
-            $part = snake_case($part);
+            $part = Str::snake($part);
         });
 
         return implode('/', $nameArray);

--- a/src/Factories/AbstractWidgetFactory.php
+++ b/src/Factories/AbstractWidgetFactory.php
@@ -9,6 +9,7 @@ use Arrilot\Widgets\Misc\EncryptException;
 use Arrilot\Widgets\Misc\InvalidWidgetClassException;
 use Arrilot\Widgets\Misc\ViewExpressionTrait;
 use Arrilot\Widgets\WidgetId;
+use Illuminate\Support\Str;
 
 abstract class AbstractWidgetFactory
 {
@@ -93,7 +94,7 @@ abstract class AbstractWidgetFactory
      * Magic method that catches all widget calls.
      *
      * @param string $widgetName
-     * @param array $params
+     * @param array  $params
      *
      * @return mixed
      */
@@ -164,7 +165,7 @@ abstract class AbstractWidgetFactory
      */
     protected function parseFullWidgetNameFromString($widgetName)
     {
-        return studly_case(str_replace('.', '\\_', $widgetName));
+        return Str::studly(str_replace('.', '\\_', $widgetName));
     }
 
     /**

--- a/src/Misc/AliasNotFoundException.php
+++ b/src/Misc/AliasNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Arrilot\Widgets\Misc;
+
+use Exception;
+
+class AliasNotFoundException extends Exception
+{
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -25,5 +25,5 @@ return [
      */
      'aliases' => [
          // 'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
-     ]
+     ],
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -24,6 +24,6 @@ return [
      * Define aliases to classes
      */
      'aliases' => [
-          'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
+         // 'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
      ]
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,11 @@ return [
     * Relative path from the base directory to a plain widget stub.
     */
     'widget_plain_stub'  => 'vendor/arrilot/laravel-widgets/src/Console/stubs/widget_plain.stub',
+
+     /*
+     * Define aliases to classes
+     */
+     'aliases' => [
+          'test' => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class
+     ]
 ];

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -6,9 +6,9 @@ use Arrilot\Widgets\AbstractWidget;
 use Arrilot\Widgets\Contracts\ApplicationWrapperContract;
 use Arrilot\Widgets\Factories\AsyncWidgetFactory;
 use Arrilot\Widgets\Factories\WidgetFactory;
-use Illuminate\Container\Container;
 use Closure;
 use Doctrine\Instantiator\Exception\InvalidArgumentException;
+use Illuminate\Container\Container;
 
 class TestApplicationWrapper implements ApplicationWrapperContract
 {
@@ -57,7 +57,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Get the specified configuration value.
      *
      * @param string $key
-     * @param mixed $default
+     * @param mixed  $default
      *
      * @return mixed
      */
@@ -84,7 +84,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Wrapper around app()->make().
      *
      * @param string $abstract
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return mixed
      */

--- a/tests/Support/TestApplicationWrapper.php
+++ b/tests/Support/TestApplicationWrapper.php
@@ -20,6 +20,9 @@ class TestApplicationWrapper implements ApplicationWrapperContract
     public $config = [
         'laravel-widgets.default_namespace'         => 'Arrilot\Widgets\Test\Dummies',
         'laravel-widgets.use_jquery_for_ajax_calls' => true,
+        'laravel-widgets.aliases.valid'             => \Arrilot\Widgets\Test\Dummies\TestDefaultSlider::class,
+        'laravel-widgets.aliases.invalid'           => \Arrilot\Widgets\Test\Dummies\Invalid::class,
+        'laravel-widgets.aliases.empty'             => '',
     ];
 
     /**
@@ -54,7 +57,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Get the specified configuration value.
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */
@@ -81,7 +84,7 @@ class TestApplicationWrapper implements ApplicationWrapperContract
      * Wrapper around app()->make().
      *
      * @param string $abstract
-     * @param array  $parameters
+     * @param array $parameters
      *
      * @return mixed
      */

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -68,6 +68,27 @@ class WidgetFactoryTest extends TestCase
         $this->assertEquals('Default test slider was executed with $slides = 6', $output);
     }
 
+    public function testItCanRunWidgetsUsingAlias()
+    {
+        $output = $this->factory->run('valid');
+
+        $this->assertEquals('Default test slider was executed with $slides = 6', $output);
+    }
+
+    public function testItThrowsExceptionForBadAlias()
+    {
+        $this->expectException('\Arrilot\Widgets\Misc\InvalidWidgetClassException');
+
+        $output = $this->factory->run('invalid');
+    }
+
+    public function testItThrowsExceptionForEmptyAlias()
+    {
+        $this->expectException('\Arrilot\Widgets\Misc\AliasNotFoundException');
+
+        $output = $this->factory->run('empty');
+    }
+
     public function testItLoadsWidgetsFromRootNamespaceFirst()
     {
         $output = $this->factory->run('Exception');
@@ -110,16 +131,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<div id="arrilot-widget-container-1" style="display:inline" class="arrilot-widget-container">Feed was executed with $slides = 6'.
-                '<script type="text/javascript">'.
-                    'setTimeout( function() {'.
-                        'var widgetTimer1 = setInterval(function() {'.
-                            'if (window.$) {'.
-                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
-                                'clearInterval(widgetTimer1);'.
-                            '}'.
-                        '}, 100);'.
-                    '}, 10000)'.
-                '</script>'.
+            '<script type="text/javascript">'.
+            'setTimeout( function() {'.
+            'var widgetTimer1 = setInterval(function() {'.
+            'if (window.$) {'.
+            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
+            'clearInterval(widgetTimer1);'.
+            '}'.
+            '}, 100);'.
+            '}, 10000)'.
+            '</script>'.
             '</div>', $output);
     }
 
@@ -129,16 +150,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<p id="arrilot-widget-container-1" data-id="123">Dummy Content'.
-                '<script type="text/javascript">'.
-                    'setTimeout( function() {'.
-                        'var widgetTimer1 = setInterval(function() {'.
-                            'if (window.$) {'.
-                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
-                                'clearInterval(widgetTimer1);'.
-                            '}'.
-                        '}, 100);'.
-                    '}, 10000)'.
-                '</script>'.
+            '<script type="text/javascript">'.
+            'setTimeout( function() {'.
+            'var widgetTimer1 = setInterval(function() {'.
+            'if (window.$) {'.
+            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
+            'clearInterval(widgetTimer1);'.
+            '}'.
+            '}, 100);'.
+            '}, 10000)'.
+            '</script>'.
             '</p>', $output);
     }
 

--- a/tests/WidgetFactoryTest.php
+++ b/tests/WidgetFactoryTest.php
@@ -131,16 +131,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<div id="arrilot-widget-container-1" style="display:inline" class="arrilot-widget-container">Feed was executed with $slides = 6'.
-            '<script type="text/javascript">'.
-            'setTimeout( function() {'.
-            'var widgetTimer1 = setInterval(function() {'.
-            'if (window.$) {'.
-            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
-            'clearInterval(widgetTimer1);'.
-            '}'.
-            '}, 100);'.
-            '}, 10000)'.
-            '</script>'.
+                '<script type="text/javascript">'.
+                    'setTimeout( function() {'.
+                        'var widgetTimer1 = setInterval(function() {'.
+                            'if (window.$) {'.
+                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestRepeatableFeed')."');".
+                                'clearInterval(widgetTimer1);'.
+                            '}'.
+                        '}, 100);'.
+                    '}, 10000)'.
+                '</script>'.
             '</div>', $output);
     }
 
@@ -150,16 +150,16 @@ class WidgetFactoryTest extends TestCase
 
         $this->assertEquals(
             '<p id="arrilot-widget-container-1" data-id="123">Dummy Content'.
-            '<script type="text/javascript">'.
-            'setTimeout( function() {'.
-            'var widgetTimer1 = setInterval(function() {'.
-            'if (window.$) {'.
-            "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
-            'clearInterval(widgetTimer1);'.
-            '}'.
-            '}, 100);'.
-            '}, 10000)'.
-            '</script>'.
+                '<script type="text/javascript">'.
+                    'setTimeout( function() {'.
+                        'var widgetTimer1 = setInterval(function() {'.
+                            'if (window.$) {'.
+                                "$('#arrilot-widget-container-1').load('".$this->ajaxUrl('TestWidgetWithCustomContainer')."');".
+                                'clearInterval(widgetTimer1);'.
+                            '}'.
+                        '}, 100);'.
+                    '}, 10000)'.
+                '</script>'.
             '</p>', $output);
     }
 


### PR DESCRIPTION
Hello Arrilot, me again...

I have to deliver widgets with a package. After analyzing how to make sure that widgets can be called after the installation of the package, I found this solution.

In other words, we will enter aliases in the configuration file, these aliases can then be called directly with the Blade directive. The advantage is therefore to be able to merge the configuration values to call the widgets of the package (see my modifications in README.md).

I'll let you analyze my modifications, I added the tests.

I also took the occasion to remove the deprecated helpers : https://laravel-news.com/laravel-5-8-deprecates-string-and-array-helpers