### PR TITLE
use jquery from env

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -3,7 +3,7 @@
 return [
     //'default_namespace' => 'App\Widgets',
 
-    'use_jquery_for_ajax_calls' => false,
+    'use_jquery_for_ajax_calls' => env('ARRILOT_USE_JQUERY', false),
 
     /*
     * Set Ajax widget middleware


### PR DESCRIPTION
Most of the times the only thing user is ever going to override is the jQuery use, have it in the env is very convenient so one can override it dynamically by simply updating value in the file.