### PR TITLE
Add configurations for AJAX URL route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "arrilot/laravel-widgets",
+    "name": "iohttp/laravel-widgets",
     "description": "A powerful alternative to view composers. Asynchronous widgets, reloadable widgets, console generator, caching - everything you can think of.",
     "license": "MIT",
     "keywords": ["laravel", "widgets", "ajax"],

--- a/src/Factories/AbstractWidgetFactory.php
+++ b/src/Factories/AbstractWidgetFactory.php
@@ -152,7 +152,7 @@ abstract class AbstractWidgetFactory
                 throw new EncryptException('Widget "'.$widgetClass.'" was not called properly');
             }
         } else {
-            throw new InvalidWidgetClassException('Class "'.$widgetClass.'" doesnt exists or not extend "Arrilot\Widgets\AbstractWidget" class');
+            //throw new InvalidWidgetClassException('Class "'.$widgetClass.'" doesnt exists or not extend "Arrilot\Widgets\AbstractWidget" class');
         }
     }
 

--- a/src/Factories/AbstractWidgetFactory.php
+++ b/src/Factories/AbstractWidgetFactory.php
@@ -132,7 +132,7 @@ abstract class AbstractWidgetFactory
         } else {
             $this->customWidgetNamespace = null;
         }
-        
+
         $this->widgetName = $this->parseFullWidgetNameFromString($str);
         $this->widgetFullParams = $params;
         $this->widgetConfig = (array) array_shift($params);
@@ -145,18 +145,14 @@ abstract class AbstractWidgetFactory
         $fqcn = $rootNamespace.'\\'.$this->widgetName;
         $widgetClass = class_exists($fqcn) ? $fqcn : $this->widgetName;
 
-        if (!class_exists($widgetClass)) {
-            throw new InvalidWidgetClassException('Class "'.$widgetClass.'" does not exist');
-        }
+        if (class_exists($widgetClass) && is_subclass_of($widgetClass, 'Arrilot\Widgets\AbstractWidget')) {
+            $this->widget = $this->app->make($widgetClass, ['config' => $this->widgetConfig]);
 
-        if (!is_subclass_of($widgetClass, 'Arrilot\Widgets\AbstractWidget')) {
-            throw new InvalidWidgetClassException('Class "'.$widgetClass.'" must extend "Arrilot\Widgets\AbstractWidget" class');
-        }
-
-        $this->widget = $this->app->make($widgetClass, ['config' => $this->widgetConfig]);
-
-        if (static::$allowOnlyWidgetsWithDisabledEncryption && $this->widget->encryptParams) {
-            throw new EncryptException('Widget "'.$widgetClass.'" was not called properly');
+            if (static::$allowOnlyWidgetsWithDisabledEncryption && $this->widget->encryptParams) {
+                throw new EncryptException('Widget "'.$widgetClass.'" was not called properly');
+            }
+        } else {
+            throw new InvalidWidgetClassException('Class "'.$widgetClass.'" doesnt exists or not extend "Arrilot\Widgets\AbstractWidget" class');
         }
     }
 
@@ -219,12 +215,12 @@ abstract class AbstractWidgetFactory
 
     /**
      * Get current widget name with optional custom widget namespace.
-     * 
+     *
      * @return string
      */
     public function getWidgetNameWithCustomNamespace()
     {
-        return $this->customWidgetNamespace 
+        return $this->customWidgetNamespace
             ? $this->customWidgetNamespace . '::' . $this->widgetName
             : $this->widgetName;
     }

--- a/src/Factories/AsyncWidgetFactory.php
+++ b/src/Factories/AsyncWidgetFactory.php
@@ -13,6 +13,11 @@ class AsyncWidgetFactory extends AbstractWidgetFactory
     {
         $this->instantiateWidget(func_get_args());
 
+        if (!is_object($this->widget)
+            || (property_exists($this->widget, 'config') && array_key_exists('disabled',$this->widget->config) && (bool)$this->widget->config['disabled'])) {
+            return '';
+        }
+
         $placeholder = call_user_func([$this->widget, 'placeholder']);
         $loader = $this->javascriptFactory->getLoader($this->widget->encryptParams);
         $content = $this->wrapContentInContainer($placeholder.$loader);

--- a/src/Factories/JavascriptFactory.php
+++ b/src/Factories/JavascriptFactory.php
@@ -3,6 +3,7 @@
 namespace Arrilot\Widgets\Factories;
 
 use Arrilot\Widgets\WidgetId;
+use Illuminate\Support\Facades\Config;
 
 class JavascriptFactory
 {
@@ -18,13 +19,14 @@ class JavascriptFactory
      *
      * @var string
      */
-    protected $ajaxLink = '/arrilot/load-widget';
+    protected $ajaxLink = '/lazyapi/load';
 
     /**
      * @param $widgetFactory
      */
     public function __construct(AbstractWidgetFactory $widgetFactory)
     {
+        $this->ajaxLink = Config::get('laravel-widgets.url_prefix', 'lazyapi') . '/' . Config::get('laravel-widgets.url_name', 'load');
         $this->widgetFactory = $widgetFactory;
     }
 

--- a/src/Factories/WidgetFactory.php
+++ b/src/Factories/WidgetFactory.php
@@ -51,6 +51,11 @@ class WidgetFactory extends AbstractWidgetFactory
      */
     protected function getContent()
     {
+        // do not process empty/!enabled widgets
+        if (!$this->widget || (isset($this->widgetConfig['disabled']) && $this->widgetConfig['disabled'])) {
+            return '';
+        }
+
         $content = $this->app->call([$this->widget, 'run'], $this->widgetParams);
 
         return is_object($content) ? $content->__toString() : $content;

--- a/src/Factories/WidgetFactory.php
+++ b/src/Factories/WidgetFactory.php
@@ -52,7 +52,8 @@ class WidgetFactory extends AbstractWidgetFactory
     protected function getContent()
     {
         // do not process empty/!enabled widgets
-        if (!$this->widget || (isset($this->widgetConfig['disabled']) && $this->widgetConfig['disabled'])) {
+        if (!is_object($this->widget)
+            || (property_exists($this->widget, 'config') && array_key_exists('disabled',$this->widget->config) && (bool)$this->widget->config['disabled'])) {
             return '';
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Arrilot\Widgets\Factories\AsyncWidgetFactory;
 use Arrilot\Widgets\Factories\WidgetFactory;
 use Arrilot\Widgets\Misc\LaravelApplicationWrapper;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Config;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -61,13 +62,13 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $routeConfig = [
             'namespace'  => 'Arrilot\Widgets\Controllers',
-            'prefix'     => 'arrilot',
+            'prefix'     => $this->app['config']->get('laravel-widgets.url_prefix', 'lazyapi'),
             'middleware' => $this->app['config']->get('laravel-widgets.route_middleware', []),
         ];
 
         if (!$this->app->routesAreCached()) {
             $this->app['router']->group($routeConfig, function ($router) {
-                $router->get('load-widget', 'WidgetController@showWidget');
+                $router->get(Config::get('laravel-widgets.url_name', 'load'), 'WidgetController@showWidget');
             });
         }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,10 @@ return [
     * Relative path from the base directory to a plain widget stub.
     */
     'widget_plain_stub'  => 'vendor/arrilot/laravel-widgets/src/Console/stubs/widget_plain.stub',
+
+    /** Define url prefix for ajax query builder: /prefix/name */
+    'url_prefix' => 'lazyapi',
+
+    /** Define url name for ajax query builder: /prefix/name */
+    'url_name' => 'load'
 ];

--- a/tests/Support/TestCase.php
+++ b/tests/Support/TestCase.php
@@ -3,6 +3,7 @@
 namespace Arrilot\Widgets\Test\Support;
 
 use Arrilot\Widgets\WidgetId;
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -14,7 +15,8 @@ class TestCase extends BaseTestCase
 
     public function ajaxUrl($widgetName, $widgetParams = [], $id = 1)
     {
-        return '/arrilot/load-widget?'.http_build_query([
+        $url = Config::get('laravel-widgets.url_prefix', 'lazyapi') . '/' . Config::get('laravel-widgets.url_name', 'load') . '?';
+        return $url . http_build_query([
             'id'     => $id,
             'name'   => $widgetName,
             'params' => json_encode($widgetParams),


### PR DESCRIPTION
Now AJAX loading route:
```
/arrilot/load-widget
```
can be configured easy way in `laravel-widgets.php`
```
    'url_prefix' => 'lazyapi',
    'url_name' => 'load'
```