### PR TITLE
made ajaxLink property an absolute url

### DIFF
--- a/src/Factories/JavascriptFactory.php
+++ b/src/Factories/JavascriptFactory.php
@@ -26,6 +26,7 @@ class JavascriptFactory
     public function __construct(AbstractWidgetFactory $widgetFactory)
     {
         $this->widgetFactory = $widgetFactory;
+        $this->ajaxLink = url($this->ajaxLink);
     }
 
     /**


### PR DESCRIPTION
When a site is located in subdirectory but not the root folder (site.com/sub/ and not the site.com/) async widgets will send request to root (site.com/arrilot/load-widget and not site.com/sub/arrilot/load-widget) so widgets are not loaded. I changed ajaxLink property of JavascriptFactory to be absolu url that is generated by laravel automatically (e.g. from .env with APP_URL)